### PR TITLE
La mise en forme est réparée et des bonus

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,13 @@ bin/django migrate --fake-initial
 # 7. Lancer le serveur !
 bin/django runserver
 ```
+
+## Lancer les tests
+
+'''
+#Si pas déjà dans le dossier du projet
+cd EnceFAL
+
+#On lance la suite de test de django
+bin/django test
+'''

--- a/project/development.py
+++ b/project/development.py
@@ -1,4 +1,3 @@
 
 from project.settings import *
 DEBUG=True
-TEMPLATE_DEBUG=DEBUG

--- a/project/encefal/templates/base.html
+++ b/project/encefal/templates/base.html
@@ -1,21 +1,26 @@
 <!DOCTYPE html>
 {% load bootstrap_toolkit %}
 {% load static %}
+{% load staticfiles %}
 <html>
   <head>
     <meta charset="utf-8">
     <title>{%block pagetitle %}Foire aux livres de l'AESS{% endblock pagetitle %} | EnceFAL</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    {% bootstrap_stylesheet_tag %}
-    {% bootstrap_stylesheet_tag "responsive" %}
+
+	<!-- les bootstrap_stylesheet_tag semblent passés date, j'ai hard-coded les liens 
+		meme chose pour le bootstrap_javascript_tag -->
+	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.3.2/css/bootstrap.css"> 
+	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.3.2/css/bootstrap-responsive.css">
+
     <!--[if lt IE 9]>
       <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700,800,600' rel='stylesheet' type='text/css'>
-    <link rel="stylesheet" href="{% get_static_prefix %}css/style.css" type='text/css'>
-    <link rel="shortcut icon" href="{% get_static_prefix %}images/logo_encefal.png">
+    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700,800,600' rel='stylesheet' type='text/css'/>
+    <link rel="stylesheet" href="{% static "css/style.css" %}" type='text/css'/>
+    <link rel="shortcut icon" href="{% get_static_prefix %}images/logo_encefal.png"/>
     
     {% block extra_head %}{% endblock %}
 
@@ -46,6 +51,7 @@
     <div class="container">
       {% block content %}{% endblock content %}
     </div>
-  {% bootstrap_javascript_tag %}
+	<!-- copie du lien bootstrap_javascript_tag -->
+  <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.3.2/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/project/settings.py
+++ b/project/settings.py
@@ -11,7 +11,6 @@ ADMINS = (
     # ('Nilovna Bascunan-Vasquez', 'contact@nilovna.com'),
 )
 
-
 MANAGERS = ADMINS
 
 # Local time zone for this installation. Choices can be found here:
@@ -39,8 +38,8 @@ USE_L10N = True
 
 # Absolute filesystem path to the directory that will hold user-uploaded files.
 # Example: "/home/media/media.lawrence.com/"
-MEDIA_ROOT = os.path.join(os.path.dirname(__file__), 'media')
-MEDIA_PRIVE_ROOT = os.path.join(os.path.dirname(__file__), 'media_prive')
+MEDIA_ROOT = os.path.join(os.path.dirname(BASE_DIR), 'media')
+MEDIA_PRIVE_ROOT = os.path.join(os.path.dirname(BASE_DIR), 'media_prive')
 
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a
 # trailing slash if there is a path component (optional in other cases).
@@ -55,7 +54,7 @@ ADMIN_MEDIA_PREFIX = '/static/admin/'
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = 'phgxc&v+2@4--i(t^s_d3=1w+jhw=qr*6oo2j7po(z$5*x$hup'
 
-DEBUG=False
+DEBUG=True
 
 TEMPLATES = [
     {
@@ -87,6 +86,8 @@ TEMPLATES = [
     },
 ]
 
+STATIC_ROOT = os.path.join(BASE_DIR,'project', 'encefal', 'static')
+
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -94,6 +95,10 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
 )
+
+BOOTSTRAP3 = {
+	'base_url': '//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/'
+}
 
 ROOT_URLCONF = 'project.urls'
 


### PR DESCRIPTION
Patches for issue #14 #16

La version utilisé de bootstrap-toolkit possède certains éléments incompatibles, notamment bootstrap_stylesheet_tag, qui permettait d'avoir accès aux mises en formes.

J'ai simplement hardcoder le lien de la tag infonctionnel, et voilà !
De plus, j'ai ajouté et modifié certains éléments dans les settings pour les fichiers statiques.
Tercio, j'ai ajouté les test au README.md.
Finalement, j'ai réussi à enlever le warning lors du makemigrate (1.8_W0001).

Sur ce, bonne nuit ! :1234: 
